### PR TITLE
feat: use server-returned affected rows in BulkWriter

### DIFF
--- a/src/GreptimeDB.Ingester/Client/BulkWriter.cs
+++ b/src/GreptimeDB.Ingester/Client/BulkWriter.cs
@@ -56,14 +56,15 @@ public sealed partial class BulkWriter : IBulkWriter
         ThrowIfDisposed();
         ThrowIfCompleted();
 
-        if (_recvError != null)
+        var recvError = _recvError;
+        if (recvError != null)
         {
-            if (_recvError is GreptimeException)
+            if (recvError is GreptimeException greptimeEx)
             {
-                throw _recvError;
+                throw greptimeEx;
             }
 
-            throw new GreptimeException($"Stream already failed: {_recvError.Message}", _recvError);
+            throw new GreptimeException($"Stream already failed: {recvError.Message}", recvError);
         }
 
         using var recordBatch = _recordBatchBuilder.Build(table);
@@ -117,14 +118,15 @@ public sealed partial class BulkWriter : IBulkWriter
                 await _recvTask.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
             }
 
-            if (_recvError != null)
+            var error = _recvError;
+            if (error != null)
             {
-                if (_recvError is GreptimeException)
+                if (error is GreptimeException greptimeEx)
                 {
-                    throw _recvError;
+                    throw greptimeEx;
                 }
 
-                throw new GreptimeException($"Bulk write failed: {_recvError.Message}", _recvError);
+                throw new GreptimeException($"Bulk write failed: {error.Message}", error);
             }
 
             LogBulkWriteCompleted(_logger, _serverAffectedRows);
@@ -136,6 +138,7 @@ public sealed partial class BulkWriter : IBulkWriter
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
+            _cts.Cancel();
             throw new TimeoutException(
                 $"Bulk write operation timed out after {_writeTimeout.TotalSeconds} seconds.");
         }
@@ -245,15 +248,15 @@ public sealed partial class BulkWriter : IBulkWriter
         }
         catch (OperationCanceledException ex)
         {
-            error ??= ex;
+            error = ex;
         }
         catch (RpcException ex)
         {
-            error ??= ex;
+            error = ex;
         }
         catch (ObjectDisposedException ex)
         {
-            error ??= ex;
+            error = ex;
         }
 
         return (affectedRows, error);

--- a/src/GreptimeDB.Ingester/Client/BulkWriter.cs
+++ b/src/GreptimeDB.Ingester/Client/BulkWriter.cs
@@ -20,6 +20,7 @@ public sealed partial class BulkWriter : IBulkWriter
     private readonly FlightClient _flightClient;
     private readonly string _database;
     private readonly AuthenticationOptions? _auth;
+    private readonly TimeSpan _writeTimeout;
     private readonly ILogger _logger;
     private readonly RecordBatchBuilder _recordBatchBuilder;
 
@@ -36,11 +37,13 @@ public sealed partial class BulkWriter : IBulkWriter
         FlightClient flightClient,
         string database,
         AuthenticationOptions? auth,
+        TimeSpan writeTimeout,
         ILogger? logger = null)
     {
         _flightClient = flightClient;
         _database = database;
         _auth = auth;
+        _writeTimeout = writeTimeout;
         _logger = logger ?? NullLogger.Instance;
         _recordBatchBuilder = new RecordBatchBuilder();
 
@@ -104,11 +107,14 @@ public sealed partial class BulkWriter : IBulkWriter
 
         try
         {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(_writeTimeout);
+
             await _putCall.RequestStream.CompleteAsync().ConfigureAwait(false);
 
             if (_recvTask != null)
             {
-                await _recvTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _recvTask.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
             }
 
             if (_recvError != null)
@@ -127,6 +133,11 @@ public sealed partial class BulkWriter : IBulkWriter
         catch (GreptimeException)
         {
             throw;
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"Bulk write operation timed out after {_writeTimeout.TotalSeconds} seconds.");
         }
         catch (RpcException ex)
         {

--- a/src/GreptimeDB.Ingester/Client/BulkWriter.cs
+++ b/src/GreptimeDB.Ingester/Client/BulkWriter.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Apache.Arrow;
 using Apache.Arrow.Flight;
 using Apache.Arrow.Flight.Client;
@@ -23,13 +25,12 @@ public sealed partial class BulkWriter : IBulkWriter
 
     private FlightRecordBatchDuplexStreamingCall? _putCall;
     private string? _currentTableName;
-    private uint _totalRowsWritten;
+    private Task? _recvTask;
+    private uint _serverAffectedRows;
+    private volatile Exception? _recvError;
     private int _completed;
     private int _disposed;
 
-    /// <summary>
-    /// Creates a new BulkWriter.
-    /// </summary>
     internal BulkWriter(
         FlightClient flightClient,
         string database,
@@ -51,10 +52,13 @@ public sealed partial class BulkWriter : IBulkWriter
         ThrowIfDisposed();
         ThrowIfCompleted();
 
-        // Build the RecordBatch from the table
+        if (_recvError != null)
+        {
+            throw new GreptimeException($"Stream already failed: {_recvError.Message}", _recvError);
+        }
+
         using var recordBatch = _recordBatchBuilder.Build(table);
 
-        // Initialize the stream on first write
         if (_putCall == null)
         {
             await InitializeStreamAsync(table.Name, recordBatch.Schema, cancellationToken)
@@ -69,13 +73,8 @@ public sealed partial class BulkWriter : IBulkWriter
                 "Create a new BulkWriter for each table.");
         }
 
-        // Write the record batch. Note: gRPC/Arrow Flight do not support cancelling an individual
-        // write once it has started; we only honor cancellation before beginning the write.
         cancellationToken.ThrowIfCancellationRequested();
         await _putCall!.RequestStream.WriteAsync(recordBatch).ConfigureAwait(false);
-
-        // Track rows written (like Go ingester does)
-        _totalRowsWritten += (uint)table.RowCount;
 
         LogRecordBatchWritten(_logger, table.Name, table.RowCount);
     }
@@ -92,7 +91,6 @@ public sealed partial class BulkWriter : IBulkWriter
 
         if (_putCall == null)
         {
-            // No data was written
             return 0;
         }
 
@@ -100,18 +98,24 @@ public sealed partial class BulkWriter : IBulkWriter
 
         try
         {
-            // Complete the request stream
             await _putCall.RequestStream.CompleteAsync().ConfigureAwait(false);
 
-            // Read and consume the response stream (required to complete the RPC)
-            while (await _putCall.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false))
+            if (_recvTask != null)
             {
-                // GreptimeDB doesn't return meaningful affected rows count in Arrow Flight response.
-                // Like the Go ingester, we return the count of rows we sent.
+                await _recvTask.ConfigureAwait(false);
             }
 
-            LogBulkWriteCompleted(_logger, _totalRowsWritten);
-            return _totalRowsWritten;
+            if (_recvError != null)
+            {
+                throw new GreptimeException($"Bulk write failed: {_recvError.Message}", _recvError);
+            }
+
+            LogBulkWriteCompleted(_logger, _serverAffectedRows);
+            return _serverAffectedRows;
+        }
+        catch (GreptimeException)
+        {
+            throw;
         }
         catch (RpcException ex)
         {
@@ -131,9 +135,19 @@ public sealed partial class BulkWriter : IBulkWriter
         _putCall?.Dispose();
         _recordBatchBuilder.Dispose();
 
-        LogBulkWriterDisposed(_logger);
+        if (_recvTask != null)
+        {
+            try
+            {
+                await _recvTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignore exceptions during disposal
+            }
+        }
 
-        await ValueTask.CompletedTask;
+        LogBulkWriterDisposed(_logger);
     }
 
     private async Task InitializeStreamAsync(
@@ -141,10 +155,8 @@ public sealed partial class BulkWriter : IBulkWriter
         Schema schema,
         CancellationToken cancellationToken)
     {
-        // Create the FlightDescriptor with the table name
         var descriptor = FlightDescriptor.CreatePathDescriptor(tableName);
 
-        // Build headers for authentication
         var headers = new Metadata();
         if (_auth?.IsConfigured == true)
         {
@@ -154,11 +166,49 @@ public sealed partial class BulkWriter : IBulkWriter
         }
         headers.Add("x-greptime-db-name", _database);
 
-        // Start the DoPut call with schema
         _putCall = await _flightClient.StartPut(descriptor, schema, headers, deadline: null, cancellationToken)
             .ConfigureAwait(false);
 
+        _recvTask = DrainResponsesAsync(_putCall.ResponseStream);
+
         LogStreamInitialized(_logger, tableName);
+    }
+
+    internal async Task DrainResponsesAsync(IAsyncStreamReader<FlightPutResult> responseStream)
+    {
+        try
+        {
+            while (await responseStream.MoveNext(CancellationToken.None).ConfigureAwait(false))
+            {
+                var result = responseStream.Current;
+                if (result.ApplicationMetadata == null || result.ApplicationMetadata.IsEmpty)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var resp = JsonSerializer.Deserialize<DoPutResponse>(result.ApplicationMetadata.Span);
+                    if (resp != null)
+                    {
+                        _serverAffectedRows += resp.AffectedRows;
+                    }
+                }
+                catch (JsonException ex)
+                {
+                    _recvError ??= new GreptimeException(
+                        $"Failed to deserialize PutResult metadata: {ex.Message}", ex);
+                }
+            }
+        }
+        catch (RpcException ex)
+        {
+            _recvError ??= ex;
+        }
+        catch (ObjectDisposedException)
+        {
+            // Stream disposed during shutdown, expected
+        }
     }
 
     private void ThrowIfDisposed()
@@ -180,6 +230,12 @@ public sealed partial class BulkWriter : IBulkWriter
             throw new InvalidOperationException(
                 "Cannot write after CompleteAsync has been called.");
         }
+    }
+
+    internal sealed class DoPutResponse
+    {
+        [JsonPropertyName("affected_rows")]
+        public uint AffectedRows { get; set; }
     }
 
     #region Logging

--- a/src/GreptimeDB.Ingester/Client/BulkWriter.cs
+++ b/src/GreptimeDB.Ingester/Client/BulkWriter.cs
@@ -28,6 +28,7 @@ public sealed partial class BulkWriter : IBulkWriter
     private Task? _recvTask;
     private uint _serverAffectedRows;
     private volatile Exception? _recvError;
+    private readonly CancellationTokenSource _cts = new();
     private int _completed;
     private int _disposed;
 
@@ -54,6 +55,11 @@ public sealed partial class BulkWriter : IBulkWriter
 
         if (_recvError != null)
         {
+            if (_recvError is GreptimeException)
+            {
+                throw _recvError;
+            }
+
             throw new GreptimeException($"Stream already failed: {_recvError.Message}", _recvError);
         }
 
@@ -102,11 +108,16 @@ public sealed partial class BulkWriter : IBulkWriter
 
             if (_recvTask != null)
             {
-                await _recvTask.ConfigureAwait(false);
+                await _recvTask.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
 
             if (_recvError != null)
             {
+                if (_recvError is GreptimeException)
+                {
+                    throw _recvError;
+                }
+
                 throw new GreptimeException($"Bulk write failed: {_recvError.Message}", _recvError);
             }
 
@@ -132,6 +143,12 @@ public sealed partial class BulkWriter : IBulkWriter
             return;
         }
 
+#if NET8_0_OR_GREATER
+        await _cts.CancelAsync().ConfigureAwait(false);
+#else
+        _cts.Cancel();
+#endif
+
         _putCall?.Dispose();
         _recordBatchBuilder.Dispose();
 
@@ -141,11 +158,13 @@ public sealed partial class BulkWriter : IBulkWriter
             {
                 await _recvTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
-                // Ignore exceptions during disposal
+                LogBulkWriteError(_logger, ex.Message);
             }
         }
+
+        _cts.Dispose();
 
         LogBulkWriterDisposed(_logger);
     }
@@ -169,16 +188,28 @@ public sealed partial class BulkWriter : IBulkWriter
         _putCall = await _flightClient.StartPut(descriptor, schema, headers, deadline: null, cancellationToken)
             .ConfigureAwait(false);
 
-        _recvTask = DrainResponsesAsync(_putCall.ResponseStream);
+        _recvTask = RunRecvLoopAsync(_putCall.ResponseStream);
 
         LogStreamInitialized(_logger, tableName);
     }
 
-    internal async Task DrainResponsesAsync(IAsyncStreamReader<FlightPutResult> responseStream)
+    private async Task RunRecvLoopAsync(IAsyncStreamReader<FlightPutResult> responseStream)
     {
+        var (affectedRows, error) = await DrainResponsesAsync(responseStream, _cts.Token).ConfigureAwait(false);
+        _serverAffectedRows = affectedRows;
+        _recvError = error;
+    }
+
+    internal static async Task<(uint AffectedRows, Exception? Error)> DrainResponsesAsync(
+        IAsyncStreamReader<FlightPutResult> responseStream,
+        CancellationToken cancellationToken = default)
+    {
+        uint affectedRows = 0;
+        Exception? error = null;
+
         try
         {
-            while (await responseStream.MoveNext(CancellationToken.None).ConfigureAwait(false))
+            while (await responseStream.MoveNext(cancellationToken).ConfigureAwait(false))
             {
                 var result = responseStream.Current;
                 if (result.ApplicationMetadata == null || result.ApplicationMetadata.IsEmpty)
@@ -191,24 +222,30 @@ public sealed partial class BulkWriter : IBulkWriter
                     var resp = JsonSerializer.Deserialize<DoPutResponse>(result.ApplicationMetadata.Span);
                     if (resp != null)
                     {
-                        _serverAffectedRows += resp.AffectedRows;
+                        affectedRows += resp.AffectedRows;
                     }
                 }
                 catch (JsonException ex)
                 {
-                    _recvError ??= new GreptimeException(
+                    error ??= new GreptimeException(
                         $"Failed to deserialize PutResult metadata: {ex.Message}", ex);
                 }
             }
         }
+        catch (OperationCanceledException ex)
+        {
+            error ??= ex;
+        }
         catch (RpcException ex)
         {
-            _recvError ??= ex;
+            error ??= ex;
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException ex)
         {
-            // Stream disposed during shutdown, expected
+            error ??= ex;
         }
+
+        return (affectedRows, error);
     }
 
     private void ThrowIfDisposed()

--- a/src/GreptimeDB.Ingester/Client/GreptimeClient.cs
+++ b/src/GreptimeDB.Ingester/Client/GreptimeClient.cs
@@ -205,6 +205,7 @@ public sealed partial class GreptimeClient : IAsyncDisposable, IDisposable
             _flightClient.Value,
             _options.Database,
             _options.Authentication,
+            _options.WriteTimeout,
             _loggerFactory.CreateLogger<BulkWriter>());
     }
 

--- a/src/GreptimeDB.Ingester/Client/StreamIngestWriter.cs
+++ b/src/GreptimeDB.Ingester/Client/StreamIngestWriter.cs
@@ -150,9 +150,9 @@ public sealed partial class StreamIngestWriter : IStreamIngestWriter
         {
             await _sendTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex)
         {
-            // Ignore exceptions during disposal
+            LogStreamError(_logger, ex.Message);
         }
 
         _cts.Dispose();

--- a/tests/GreptimeDB.Ingester.Tests/BulkWriterTests.cs
+++ b/tests/GreptimeDB.Ingester.Tests/BulkWriterTests.cs
@@ -1,7 +1,7 @@
 using Apache.Arrow.Flight;
 using FluentAssertions;
-using Google.Protobuf;
 using GreptimeDB.Ingester.Client;
+using GreptimeDB.Ingester.Exceptions;
 using Grpc.Core;
 using Moq;
 using Xunit;
@@ -21,12 +21,11 @@ public class BulkWriterTests
         };
 
         var mockStream = CreateMockStream(responses);
-        var writer = CreateWriter();
 
-        await writer.DrainResponsesAsync(mockStream.Object);
+        var (affectedRows, error) = await BulkWriter.DrainResponsesAsync(mockStream.Object);
 
-        var rows = GetServerAffectedRows(writer);
-        rows.Should().Be(40);
+        affectedRows.Should().Be(40);
+        error.Should().BeNull();
     }
 
     [Fact]
@@ -36,17 +35,10 @@ public class BulkWriterTests
         mockStream.Setup(s => s.MoveNext(It.IsAny<CancellationToken>()))
             .ThrowsAsync(new RpcException(new Status(StatusCode.Internal, "server error")));
 
-        var writer = CreateWriter();
+        var (affectedRows, error) = await BulkWriter.DrainResponsesAsync(mockStream.Object);
 
-        await writer.DrainResponsesAsync(mockStream.Object);
-
-        var error = GetRecvError(writer);
+        affectedRows.Should().Be(0);
         error.Should().BeOfType<RpcException>();
-    }
-
-    private static BulkWriter CreateWriter()
-    {
-        return new BulkWriter(null!, "test-db", null);
     }
 
     private static Mock<IAsyncStreamReader<FlightPutResult>> CreateMockStream(FlightPutResult[] responses)
@@ -65,19 +57,5 @@ public class BulkWriterTests
             .Returns(() => responses[index]);
 
         return mock;
-    }
-
-    private static uint GetServerAffectedRows(BulkWriter writer)
-    {
-        var field = typeof(BulkWriter).GetField("_serverAffectedRows",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        return (uint)field!.GetValue(writer)!;
-    }
-
-    private static Exception? GetRecvError(BulkWriter writer)
-    {
-        var field = typeof(BulkWriter).GetField("_recvError",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        return (Exception?)field!.GetValue(writer);
     }
 }

--- a/tests/GreptimeDB.Ingester.Tests/BulkWriterTests.cs
+++ b/tests/GreptimeDB.Ingester.Tests/BulkWriterTests.cs
@@ -1,7 +1,6 @@
 using Apache.Arrow.Flight;
 using FluentAssertions;
 using GreptimeDB.Ingester.Client;
-using GreptimeDB.Ingester.Exceptions;
 using Grpc.Core;
 using Moq;
 using Xunit;

--- a/tests/GreptimeDB.Ingester.Tests/BulkWriterTests.cs
+++ b/tests/GreptimeDB.Ingester.Tests/BulkWriterTests.cs
@@ -1,0 +1,83 @@
+using Apache.Arrow.Flight;
+using FluentAssertions;
+using Google.Protobuf;
+using GreptimeDB.Ingester.Client;
+using Grpc.Core;
+using Moq;
+using Xunit;
+
+namespace GreptimeDB.Ingester.Tests;
+
+public class BulkWriterTests
+{
+    [Fact]
+    public async Task DrainResponsesAsync_AccumulatesAffectedRows()
+    {
+        var responses = new[]
+        {
+            new FlightPutResult("""{"affected_rows": 10}"""),
+            new FlightPutResult("""{"affected_rows": 25}"""),
+            new FlightPutResult("""{"affected_rows": 5}"""),
+        };
+
+        var mockStream = CreateMockStream(responses);
+        var writer = CreateWriter();
+
+        await writer.DrainResponsesAsync(mockStream.Object);
+
+        var rows = GetServerAffectedRows(writer);
+        rows.Should().Be(40);
+    }
+
+    [Fact]
+    public async Task DrainResponsesAsync_CapturesRpcException()
+    {
+        var mockStream = new Mock<IAsyncStreamReader<FlightPutResult>>();
+        mockStream.Setup(s => s.MoveNext(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new RpcException(new Status(StatusCode.Internal, "server error")));
+
+        var writer = CreateWriter();
+
+        await writer.DrainResponsesAsync(mockStream.Object);
+
+        var error = GetRecvError(writer);
+        error.Should().BeOfType<RpcException>();
+    }
+
+    private static BulkWriter CreateWriter()
+    {
+        return new BulkWriter(null!, "test-db", null);
+    }
+
+    private static Mock<IAsyncStreamReader<FlightPutResult>> CreateMockStream(FlightPutResult[] responses)
+    {
+        var mock = new Mock<IAsyncStreamReader<FlightPutResult>>();
+        var index = -1;
+
+        mock.Setup(s => s.MoveNext(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                index++;
+                return index < responses.Length;
+            });
+
+        mock.Setup(s => s.Current)
+            .Returns(() => responses[index]);
+
+        return mock;
+    }
+
+    private static uint GetServerAffectedRows(BulkWriter writer)
+    {
+        var field = typeof(BulkWriter).GetField("_serverAffectedRows",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        return (uint)field!.GetValue(writer)!;
+    }
+
+    private static Exception? GetRecvError(BulkWriter writer)
+    {
+        var field = typeof(BulkWriter).GetField("_recvError",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        return (Exception?)field!.GetValue(writer);
+    }
+}


### PR DESCRIPTION

BulkWriter now reads responses concurrently via a background async task, parses affected rows from `FlightPutResult.ApplicationMetadata` JSON, and supports fail-fast in WriteAsync when the server returns an error.

This aligns with the Go SDK fix for premature stream close that could cause write loss.  https://github.com/GreptimeTeam/greptimedb-ingester-go/pull/98