### PR TITLE
feat: configurable gRPC keepalive, enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `GreptimeClientOptions.KeepAlive` (`KeepAliveOptions`) to configure HTTP/2
+  keepalive on the gRPC connections shared by all write paths (unary, streaming,
+  bulk). Enabled by default with `PingDelay` 30s, `PingTimeout` 10s, and
+  `PingWhileIdle` true, so idle connections silently reset by intermediate load
+  balancers, NAT gateways, or firewalls are detected before the next write.
+
 ## [0.2.1] - 2026-06-16
 
 ### Added

--- a/src/GreptimeDB.Ingester/Client/GreptimeClient.cs
+++ b/src/GreptimeDB.Ingester/Client/GreptimeClient.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
 using Apache.Arrow.Flight.Client;
 using Greptime.V1;
 using GreptimeDB.Ingester.Exceptions;
@@ -37,7 +38,7 @@ public sealed partial class GreptimeClient : IAsyncDisposable, IDisposable
         var endpoints = options.ResolveEndpoints();
         _connections = endpoints.ToDictionary(
             endpoint => endpoint,
-            endpoint => new EndpointConnection(endpoint));
+            endpoint => new EndpointConnection(endpoint, options.KeepAlive));
         _endpointSelector = new EndpointSelector(endpoints, options.LoadBalancing, options.Failover);
 
         LogClientCreated(_logger, endpoints.Count, endpoints[0]);
@@ -414,12 +415,38 @@ public sealed partial class GreptimeClient : IAsyncDisposable, IDisposable
     {
         private readonly Lazy<FlightClient> _flightClient;
 
-        public EndpointConnection(string endpoint)
+        public EndpointConnection(string endpoint, KeepAliveOptions keepAlive)
         {
-            Channel = GrpcChannel.ForAddress(endpoint);
+            Channel = CreateChannel(endpoint, keepAlive);
             DatabaseClient = new GreptimeDatabase.GreptimeDatabaseClient(Channel);
             HealthClient = new HealthCheck.HealthCheckClient(Channel);
             _flightClient = new Lazy<FlightClient>(() => new FlightClient(Channel));
+        }
+
+        private static GrpcChannel CreateChannel(string endpoint, KeepAliveOptions keepAlive)
+        {
+            // A custom HttpHandler resets EnableMultipleHttp2Connections to false;
+            // restore GrpcChannel's default so concurrent stream/bulk writes are
+            // not funneled onto a single HTTP/2 connection.
+            var handler = new SocketsHttpHandler
+            {
+                EnableMultipleHttp2Connections = true
+            };
+
+            if (keepAlive.Enabled)
+            {
+                handler.KeepAlivePingDelay = keepAlive.PingDelay;
+                handler.KeepAlivePingTimeout = keepAlive.PingTimeout;
+                handler.KeepAlivePingPolicy = keepAlive.PingWhileIdle
+                    ? HttpKeepAlivePingPolicy.Always
+                    : HttpKeepAlivePingPolicy.WithActiveRequests;
+            }
+
+            return GrpcChannel.ForAddress(endpoint, new GrpcChannelOptions
+            {
+                HttpHandler = handler,
+                DisposeHttpClient = true
+            });
         }
 
         public GrpcChannel Channel { get; }

--- a/src/GreptimeDB.Ingester/Client/GreptimeClientOptions.cs
+++ b/src/GreptimeDB.Ingester/Client/GreptimeClientOptions.cs
@@ -62,6 +62,14 @@ public sealed class GreptimeClientOptions
     public FailoverOptions Failover { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets HTTP/2 keepalive for the gRPC connections shared by all write
+    /// paths (unary, streaming, bulk). Enabled by default to detect silent
+    /// connection resets by intermediate load balancers, NAT gateways, or
+    /// firewalls before the next write hits a dead connection.
+    /// </summary>
+    public KeepAliveOptions KeepAlive { get; set; } = new();
+
+    /// <summary>
     /// Returns the effective endpoint list: trimmed, non-whitespace entries of
     /// <see cref="Endpoints"/> when the caller populated that list. Falls back
     /// to a single-element list containing the deprecated <see cref="Endpoint"/>
@@ -172,6 +180,13 @@ public sealed class GreptimeClientOptions
         }
 
         Failover.Validate();
+
+        if (KeepAlive == null)
+        {
+            throw new ArgumentException("KeepAlive is required.", nameof(KeepAlive));
+        }
+
+        KeepAlive.Validate();
     }
 }
 
@@ -261,6 +276,66 @@ public sealed class FailoverOptions
             throw new ArgumentException(
                 "MaxEjectionDelay must be greater than or equal to BaseEjectionDelay.",
                 nameof(MaxEjectionDelay));
+        }
+    }
+}
+
+/// <summary>
+/// HTTP/2 keepalive options for the gRPC connections.
+/// </summary>
+public sealed class KeepAliveOptions
+{
+    // SocketsHttpHandler rejects ping intervals below 1s; validate rather than let it throw at runtime.
+    private static readonly TimeSpan MinInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets or sets whether keepalive pings are sent. Enabled by default.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the idle delay before the client sends a keepalive ping.
+    /// Defaults to 30 seconds, matching GreptimeDB's internal gRPC client.
+    /// </summary>
+    public TimeSpan PingDelay { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets how long to wait for a ping acknowledgement before closing
+    /// the connection. Defaults to 10 seconds.
+    /// </summary>
+    public TimeSpan PingTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets or sets whether to ping while the connection is idle (no active
+    /// calls). Defaults to true; safe because GreptimeDB's server does not
+    /// enforce a minimum ping interval. This is what protects idle streaming
+    /// connections from silent resets.
+    /// </summary>
+    public bool PingWhileIdle { get; set; } = true;
+
+    /// <summary>
+    /// Validates the keepalive options and throws if invalid.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when options are invalid.</exception>
+    public void Validate()
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        if (PingDelay < MinInterval)
+        {
+            throw new ArgumentException(
+                $"PingDelay must be at least {MinInterval.TotalSeconds} second(s) when keepalive is enabled.",
+                nameof(PingDelay));
+        }
+
+        if (PingTimeout < MinInterval)
+        {
+            throw new ArgumentException(
+                $"PingTimeout must be at least {MinInterval.TotalSeconds} second(s) when keepalive is enabled.",
+                nameof(PingTimeout));
         }
     }
 }

--- a/tests/GreptimeDB.Ingester.Tests/GreptimeClientOptionsTests.cs
+++ b/tests/GreptimeDB.Ingester.Tests/GreptimeClientOptionsTests.cs
@@ -263,4 +263,72 @@ public class GreptimeClientOptionsTests
 
         act.Should().Throw<ArgumentException>().WithMessage("*Failover*");
     }
+
+    [Fact]
+    public void KeepAlive_DefaultsToEnabled()
+    {
+        var keepAlive = new GreptimeClientOptions().KeepAlive;
+
+        keepAlive.Enabled.Should().BeTrue();
+        keepAlive.PingDelay.Should().Be(TimeSpan.FromSeconds(30));
+        keepAlive.PingTimeout.Should().Be(TimeSpan.FromSeconds(10));
+        keepAlive.PingWhileIdle.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_KeepAlivePingDelayBelowMinimum_Throws()
+    {
+        var options = new GreptimeClientOptions
+        {
+            KeepAlive = new KeepAliveOptions { PingDelay = TimeSpan.FromMilliseconds(500) }
+        };
+
+        var act = () => options.Validate();
+
+        act.Should().Throw<ArgumentException>().WithMessage("*PingDelay*");
+    }
+
+    [Fact]
+    public void Validate_KeepAlivePingTimeoutBelowMinimum_Throws()
+    {
+        var options = new GreptimeClientOptions
+        {
+            KeepAlive = new KeepAliveOptions { PingTimeout = TimeSpan.Zero }
+        };
+
+        var act = () => options.Validate();
+
+        act.Should().Throw<ArgumentException>().WithMessage("*PingTimeout*");
+    }
+
+    [Fact]
+    public void Validate_DisabledKeepAlive_SkipsIntervalChecks()
+    {
+        var options = new GreptimeClientOptions
+        {
+            KeepAlive = new KeepAliveOptions
+            {
+                Enabled = false,
+                PingDelay = TimeSpan.Zero,
+                PingTimeout = TimeSpan.Zero
+            }
+        };
+
+        var act = () => options.Validate();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_NullKeepAlive_Throws()
+    {
+        var options = new GreptimeClientOptions
+        {
+            KeepAlive = null!
+        };
+
+        var act = () => options.Validate();
+
+        act.Should().Throw<ArgumentException>().WithMessage("*KeepAlive*");
+    }
 }


### PR DESCRIPTION
## What

Add `GreptimeClientOptions.KeepAlive` (`KeepAliveOptions`) to configure HTTP/2 keepalive on the gRPC channel shared by all write paths (unary write/delete, streaming ingest, bulk Arrow Flight). **Enabled by default.**

Defaults: `PingDelay` 30s, `PingTimeout` 10s, `PingWhileIdle` true.

## Why

All write paths share a single channel created via `GrpcChannel.ForAddress` with no keepalive. .NET's `SocketsHttpHandler` defaults to no HTTP/2 keepalive ping, so an idle connection silently reset by an intermediate load balancer, NAT gateway, or firewall only surfaces as an error on the *next* write — worst for long-idle streaming connections, which have no automatic replay.

Rationale for the defaults (all grounded in code, not guesswork):

- **Safe to enable by default.** GreptimeDB's frontend gRPC server (tonic) does not send server keepalive and does not enforce a minimum client ping interval (`too_many_pings`) the way grpc-go servers do (default `MinTime=5min` + `PermitWithoutStream=false`). So `PingWhileIdle=true` (→ `HttpKeepAlivePingPolicy.Always`, equivalent to Go's `PermitWithoutStream: true`) will not get us kicked with a GOAWAY.
- **30s** matches GreptimeDB's own internal gRPC client (`channel_manager.rs`: `http2_keep_alive_interval=30s`, `keep_alive_while_idle=true`), keeping ecosystem behavior consistent.

Note this is more proactive than the Go ingester, whose keepalive is *off* unless `WithKeepalive` is called; enabling by default is a deliberate choice given the shared long-lived channel.

## Implementation notes

- Supplying a custom `HttpHandler` resets `EnableMultipleHttp2Connections` to `false`; restored to `true` to preserve `GrpcChannel`'s default and avoid funneling concurrent stream/bulk writes onto one HTTP/2 connection.
- `DisposeHttpClient = true` so the self-created handler is released with the channel.
- Ping intervals below 1s are rejected in `Validate()` (with an `Enabled=false` short-circuit) rather than letting `SocketsHttpHandler` throw at runtime.

## Tests

`GreptimeClientOptionsTests`: defaults, `PingDelay`/`PingTimeout` lower bound, disabled-skips-validation, null check. Full suite green.